### PR TITLE
Convert to lib

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -22,11 +22,22 @@ pub struct Config {
 }
 
 impl Config {
+    /// Adds an organization and its corresponding token to the configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - A `String` representing the name of the organization.
+    /// * `token` - A `String` representing the token associated with the organization.
     pub fn add_organization(&mut self, name: String, token: String) {
         let projects = &mut self.organizations;
         projects.insert(name, token);
     }
 
+    /// Creates a new configuration file on the filesystem based on the current configuration.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the `Config` if successful, or a `String` with an error message.
     pub fn create(self) -> Result<Config, String> {
         let json = json!(self).to_string();
         let mut file = fs::File::create(&self.path).or(Err("Could not create file"))?;
@@ -36,6 +47,15 @@ impl Config {
         Ok(self)
     }
 
+    /// Loads a configuration from a specified file path.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - A `&str` representing the path to the configuration file.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the `Config` if successful, or a `String` with an error message.
     pub fn load(path: &str) -> Result<Config, String> {
         let mut json = String::new();
 
@@ -47,6 +67,11 @@ impl Config {
         serde_json::from_str::<Config>(&json).map_err(|_| format!("Could not parse JSON:\n{json}"))
     }
 
+    /// Creates a new `Config` instance with default values.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the `Config` if successful, or a `String` with an error message.
     pub fn new() -> Result<Config, String> {
         let organizations: HashMap<String, String> = HashMap::new();
         Ok(Config {
@@ -59,14 +84,33 @@ impl Config {
         })
     }
 
+    /// Removes an organization from the configuration by its name.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - A `&String` representing the name of the organization to be removed.
     pub fn remove_organization(&mut self, name: &String) {
         self.organizations.remove(name);
     }
 
+    /// Retrieves a list of organization names currently in the configuration.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Vec<String>` containing the names of all organizations.
     pub fn organization_names(&self) -> Vec<String> {
         self.organizations.clone().into_keys().collect()
     }
 
+    /// Retrieves the token associated with a given organization name.
+    ///
+    /// # Arguments
+    ///
+    /// * `organization_name` - A `&String` representing the name of the organization.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the `String` token if successful, or a `String` with an error message.
     pub fn token(&self, organization_name: &String) -> Result<String, String> {
         let maybe_org = self
             .organizations
@@ -80,6 +124,11 @@ impl Config {
         }
     }
 
+    /// Saves the current configuration to the file specified by `path`.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing a confirmation `String` if successful, or a `String` with an error message.
     pub fn save(&mut self) -> std::result::Result<String, String> {
         let json = json!(self);
         let string = serde_json::to_string_pretty(&json).or(Err("Could not convert to JSON"))?;
@@ -97,6 +146,15 @@ impl Config {
     }
 }
 
+/// Retrieves the configuration from the specified path or creates a new one if it does not exist.
+///
+/// # Arguments
+///
+/// * `config_path` - An `Option<String>` representing the path to the configuration file. If `None`, a default path is used.
+///
+/// # Returns
+///
+/// Returns a `Result` containing the `Config` if successful, or a `String` with an error message.
 pub fn get_or_create(config_path: Option<String>) -> Result<Config, String> {
     let path: String = match config_path {
         None => generate_path()?,
@@ -109,6 +167,11 @@ pub fn get_or_create(config_path: Option<String>) -> Result<Config, String> {
     }
 }
 
+/// Generates the path to the configuration file, either in the default location or a temporary test directory.
+///
+/// # Returns
+///
+/// Returns a `Result` containing the `String` path if successful, or a `String` with an error message.
 pub fn generate_path() -> Result<String, String> {
     let config_directory = dirs::config_dir()
         .ok_or_else(|| String::from("Could not find config directory"))?
@@ -123,6 +186,7 @@ pub fn generate_path() -> Result<String, String> {
         Ok(format!("{config_directory}/lnr.cfg"))
     }
 }
+
 
 #[cfg(test)]
 mod tests {

--- a/src/issue.rs
+++ b/src/issue.rs
@@ -420,6 +420,24 @@ impl Display for Issue {
     }
 }
 #[allow(clippy::too_many_arguments)]
+/// Creates a new issue in the system with the given parameters.
+///
+/// # Arguments
+///
+/// * `config` - A reference to the `Config` containing the necessary configurations.
+/// * `token` - A string slice representing the authentication token.
+/// * `title` - A `String` representing the title of the issue.
+/// * `description` - A `String` representing the description of the issue.
+/// * `team` - The `Team` to which the issue belongs.
+/// * `project` - An optional `Project` to which the issue might be associated.
+/// * `state` - The `State` indicating the current state of the issue.
+/// * `assignee_id` - A `String` representing the ID of the assignee.
+/// * `priority` - The `Priority` level of the issue.
+///
+/// # Returns
+///
+/// Returns a `Result` containing the URL and branch name of the created issue as a `String` if successful,
+/// or an error message as a `String`.
 pub fn create(
     config: &Config,
     token: &str,
@@ -449,6 +467,20 @@ pub fn create(
     Ok(format!("{url}\n{branch_name}"))
 }
 
+/// Lists all issues for the given parameters, filtering by assignee, team, and project.
+///
+/// # Arguments
+///
+/// * `config` - A reference to the `Config` containing the necessary configurations.
+/// * `token` - A string slice representing the authentication token.
+/// * `assignee_id` - An optional `String` representing the ID of the assignee.
+/// * `team` - An optional `Team` to filter the issues.
+/// * `project` - An optional `Project` to filter the issues.
+///
+/// # Returns
+///
+/// Returns a `Result` containing a formatted string of all issues if successful,
+/// or an error message as a `String`.
 pub fn list(
     config: &Config,
     token: &str,
@@ -503,6 +535,18 @@ fn get_issues(
     issue_list_response(response)
 }
 
+/// Displays the details of an issue based on the given branch or allows selection from a list of issues.
+///
+/// # Arguments
+///
+/// * `config` - A reference to the `Config` containing the necessary configurations.
+/// * `token` - A string slice representing the authentication token.
+/// * `branch` - An optional `String` representing the branch name to filter the issue.
+///
+/// # Returns
+///
+/// Returns a `Result` containing the formatted issue details as a `String` if successful,
+/// or an error message as a `String`.
 pub fn view(config: &Config, token: &str, branch: Option<String>) -> Result<String, String> {
     if let Some(branch) = branch {
         let response = request::Gql::new(config, token, ISSUE_BRANCH_VIEW_DOC)
@@ -527,12 +571,24 @@ pub fn view(config: &Config, token: &str, branch: Option<String>) -> Result<Stri
     }
 }
 
+/// Edits the description of an issue identified by the given branch name.
+///
+/// # Arguments
+///
+/// * `config` - A reference to the `Config` containing the necessary configurations.
+/// * `token` - A string slice representing the authentication token.
+/// * `branch` - A `String` representing the branch name of the issue.
+///
+/// # Returns
+///
+/// Returns a `Result` containing the URL of the updated issue as a `String` if successful,
+/// or an error message as a `String`.
 pub fn edit(config: &Config, token: &str, branch: String) -> Result<String, String> {
     let response = request::Gql::new(config, token, ISSUE_BRANCH_VIEW_DOC)
         .put_string("branchName", branch.clone())
         .run()?;
     let issue = issue_branch_view_response(response, &branch)?;
-    // Stops wierd spinner output from rolling into the input text
+    // Stops weird spinner output from rolling into the input text
     println!();
     let description = input::editor(
         "Enter updated description",

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,17 +2,18 @@ extern crate clap;
 #[cfg(test)]
 extern crate matches;
 
+pub mod config;
+pub mod issue;
+pub mod request;
+pub mod team;
+pub mod template;
+pub mod viewer;
+
 mod color;
-mod config;
 mod git;
 mod input;
-mod issue;
 mod priority;
-mod request;
-mod team;
-mod template;
 mod test;
-mod viewer;
 
 use clap::{Parser, Subcommand};
 use colored::*;

--- a/src/request.rs
+++ b/src/request.rs
@@ -36,6 +36,17 @@ pub struct Gql {
 }
 
 impl Gql {
+    /// Creates a new `Gql` instance for executing GraphQL queries.
+    ///
+    /// # Arguments
+    ///
+    /// * `config` - A reference to the `Config` containing the necessary configurations.
+    /// * `token` - A string slice representing the authentication token.
+    /// * `query` - A string slice representing the GraphQL query to be executed.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Gql` instance initialized with the provided parameters.
     pub fn new(config: &Config, token: &str, query: &str) -> Gql {
         Gql {
             config: config.clone(),
@@ -45,29 +56,73 @@ impl Gql {
         }
     }
 
+    /// Inserts a set of variables into the `Gql` instance for use in the GraphQL query.
+    ///
+    /// # Arguments
+    ///
+    /// * `variables` - A `HashMap<String, Value>` containing the variables to be used in the GraphQL query.
+    ///
+    /// # Returns
+    ///
+    /// Returns the updated `Gql` instance with the provided variables.
     pub fn put_variables(mut self, variables: HashMap<String, Value>) -> Gql {
         self.variables = variables;
         self
     }
 
+    /// Inserts a string variable into the `Gql` instance for use in the GraphQL query.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - A string slice representing the key for the variable.
+    /// * `value` - A `String` representing the value of the variable.
+    ///
+    /// # Returns
+    ///
+    /// Returns the updated `Gql` instance with the provided variable.
     pub fn put_string(mut self, key: &str, value: String) -> Gql {
         self.variables.insert(key.to_string(), Value::String(value));
-
         self
     }
+
+    /// Inserts an integer variable into the `Gql` instance for use in the GraphQL query.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - A string slice representing the key for the variable.
+    /// * `value` - A `u8` representing the value of the variable.
+    ///
+    /// # Returns
+    ///
+    /// Returns the updated `Gql` instance with the provided variable.
     pub fn put_integer(mut self, key: &str, value: u8) -> Gql {
         self.variables.insert(key.to_string(), json!(value));
-
         self
     }
+
+    /// Conditionally inserts a string variable into the `Gql` instance if the value is `Some`.
+    ///
+    /// # Arguments
+    ///
+    /// * `key` - A string slice representing the key for the variable.
+    /// * `value` - An `Option<String>` representing the value of the variable. If `None`, the variable is not inserted.
+    ///
+    /// # Returns
+    ///
+    /// Returns the updated `Gql` instance with the provided variable if it exists.
     pub fn maybe_put_string(mut self, key: &str, value: Option<String>) -> Gql {
         if let Some(value) = value {
             self.variables.insert(key.to_string(), Value::String(value));
         }
-
         self
     }
 
+    /// Executes the GraphQL query with the current configuration and variables.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` containing the response as a `String` if successful,
+    /// or an error message as a `String`.
     pub fn run(self) -> Result<String, String> {
         let url = get_base_url(&self.config);
 
@@ -100,7 +155,12 @@ impl Gql {
     }
 }
 
-/// Get latest version number from Cargo.io
+/// Retrieves the latest version number of the `lnr` crate from Cargo.io.
+///
+/// # Returns
+///
+/// Returns a `Result` containing the latest version number as a `String` if successful,
+/// or an error message as a `String`.
 pub fn get_latest_version() -> Result<String, String> {
     let request_url = format!("{CARGO_URL}{VERSIONS_URL}");
 

--- a/src/team.rs
+++ b/src/team.rs
@@ -19,54 +19,92 @@ const TEAM_STATES_DOC: &str = "
             }
         }";
 
+/// Represents the response data structure for querying a team's states.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct TeamData {
     data: Data,
 }
 
+/// Represents the data structure containing team information in the response.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 struct Data {
     team: Team,
 }
 
+/// Describes a Linear team and its various projects.
 #[derive(Serialize, Default, Deserialize, Debug, Clone)]
 pub struct Team {
+    /// The name of the team.
     pub name: String,
+    /// The unique identifier of the team.
     pub id: String,
+    /// An optional collection of projects associated with the team.
     pub projects: Option<ProjectNode>,
+    /// An optional collection of states associated with the team.
     pub states: Option<StateNode>,
 }
 
+/// Represents a collection of projects within a team.
 #[derive(Serialize, Deserialize, Default, Debug, Clone)]
 pub struct ProjectNode {
+    /// A list of projects associated with the team.
     pub nodes: Vec<Project>,
 }
 
+/// Represents a single project within a team.
 #[derive(Serialize, Default, Deserialize, Debug, Clone)]
 pub struct Project {
+    /// The name of the project.
     pub name: String,
+    /// The unique identifier of the project.
     pub id: String,
 }
 
+/// Represents a collection of states within a team.
 #[derive(Serialize, Default, Deserialize, Debug, Clone)]
 pub struct StateNode {
+    /// A list of states associated with the team.
     pub nodes: Vec<State>,
 }
 
+/// Represents a single state within a team.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct State {
+    /// The name of the state.
     pub name: String,
+    /// The unique identifier of the state.
     pub id: String,
+    /// The position of the state, used for ordering.
     pub position: f32,
 }
 
 impl Display for State {
-    /// This is for rendering in a select
+    /// Formats the `State` for display, typically used in selection interfaces.
+    ///
+    /// # Arguments
+    ///
+    /// * `f` - A mutable reference to the formatter.
+    ///
+    /// # Returns
+    ///
+    /// Returns a `Result` indicating whether the formatting was successful.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let name = self.name.clone();
         write!(f, "{name}")
     }
 }
+
+/// Retrieves the states associated with a given team from the Linear API.
+///
+/// # Arguments
+///
+/// * `config` - A reference to the `Config` containing the necessary configurations.
+/// * `token` - A string slice representing the authentication token.
+/// * `team` - A reference to the `Team` whose states are to be retrieved.
+///
+/// # Returns
+///
+/// Returns a `Result` containing a `Vec<State>` if successful, or an error message as a `String`.
 pub fn get_states(config: &Config, token: &str, team: &Team) -> Result<Vec<State>, String> {
     let response = request::Gql::new(config, token, TEAM_STATES_DOC)
         .put_string("id", team.id.clone())
@@ -81,3 +119,4 @@ pub fn get_states(config: &Config, token: &str, team: &Team) -> Result<Vec<State
         Err(err) => Err(format!("Could not parse response for states: {err:?}")),
     }
 }
+

--- a/src/template.rs
+++ b/src/template.rs
@@ -46,30 +46,46 @@ const ISSUE_CREATE_DOC: &str = "mutation (
                 ";
 
 #[derive(Deserialize)]
+/// Represents the structure of a template used to create issues.
 struct Template {
+    /// The parent issue details.
     parent: ParentIssue,
+    /// An optional list of child issues.
     children: Option<Vec<ChildIssue>>,
+    /// A map of variables to be substituted in the template.
     variables: HashMap<String, String>,
 }
 
 #[derive(Deserialize)]
+/// Represents the details of a parent issue.
 struct ParentIssue {
+    /// The title of the parent issue.
     title: String,
+    /// An optional description of the parent issue.
     description: Option<String>,
 }
+
 #[derive(Deserialize)]
+/// Represents the details of a child issue.
 struct ChildIssue {
+    /// The title of the child issue.
     title: String,
+    /// An optional description of the child issue.
     description: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
+/// Represents the response structure when creating an issue.
 struct IssueCreateResponse {
+    /// The data returned from the issue creation.
     data: Option<Data>,
 }
+
 #[derive(Deserialize, Serialize, Debug)]
 #[allow(non_snake_case)]
+/// Represents the data structure containing the created issue details.
 struct Data {
+    /// The created issue details.
     issueCreate: IssueCreate,
 }
 
@@ -79,13 +95,30 @@ struct IssueCreate {
 }
 
 #[derive(Deserialize, Serialize, Debug)]
+/// Represents the details of a created issue.
 struct Issue {
+    /// The unique identifier of the created issue.
     id: String,
+    /// The URL of the created issue.
     url: String,
 }
 
-/// We want to support a file path or a directory
-#[allow(clippy::too_many_arguments)]
+/// Evaluates the specified path, creating issues based on the provided template.
+///
+/// # Arguments
+///
+/// * `config` - A reference to the `Config` containing the necessary configurations.
+/// * `token` - A string slice representing the authentication token.
+/// * `team` - A reference to the `Team` where the issues will be created.
+/// * `project` - An optional reference to the `Project` where the issues will be associated.
+/// * `viewer` - A reference to the `Viewer` who is creating the issues.
+/// * `path` - A string reference representing the path to the template file or directory.
+/// * `state` - A reference to the `State` in which the issues will be created.
+/// * `priority` - A reference to the `Priority` level of the issues.
+///
+/// # Returns
+///
+/// Returns a `Result` containing a `String` message if successful, or an error message as a `String`.
 pub fn evaluate(
     config: &Config,
     token: &str,
@@ -119,7 +152,22 @@ pub fn evaluate(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
+/// Creates issues based on the provided template file.
+///
+/// # Arguments
+///
+/// * `config` - A reference to the `Config` containing the necessary configurations.
+/// * `token` - A string slice representing the authentication token.
+/// * `team` - A reference to the `Team` where the issues will be created.
+/// * `viewer` - A reference to the `Viewer` who is creating the issues.
+/// * `project` - An optional reference to the `Project` where the issues will be associated.
+/// * `path` - A string reference representing the path to the template file.
+/// * `state` - A reference to the `State` in which the issues will be created.
+/// * `priority` - A reference to the `Priority` level of the issues.
+///
+/// # Returns
+///
+/// Returns a `Result` containing a `String` message if successful, or an error message as a `String`.
 fn create_issues(
     config: &Config,
     token: &str,

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -28,33 +28,55 @@ const FETCH_IDS_DOC: &str = "
         }";
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+/// Represents the top-level structure of the response for fetching viewer data.
 struct ViewerData {
+    /// The data field containing viewer-related information.
     data: Data,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+/// Represents the data structure containing viewer information.
 struct Data {
+    /// The viewer field containing detailed information about the viewer.
     viewer: Viewer,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
+/// Represents a viewer with their associated teams and projects.
 pub struct Viewer {
+    /// The unique identifier of the viewer.
     pub id: String,
+    /// The name of the viewer.
     name: String,
+    /// The teams the viewer is a member of, along with their associated projects.
     team_memberships: TeamMemberships,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+/// Represents the structure containing a list of team memberships.
 struct TeamMemberships {
+    /// A vector of team nodes, each representing a team the viewer is a member of.
     nodes: Vec<TeamNode>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+/// Represents a single team node, containing information about a specific team.
 struct TeamNode {
+    /// The team associated with this node.
     team: Team,
 }
 
+/// Fetches the viewer information, including their teams and projects, from the API.
+///
+/// # Arguments
+///
+/// * `config` - A reference to the `Config` containing the necessary configurations.
+/// * `token` - A string slice representing the authentication token.
+///
+/// # Returns
+///
+/// Returns a `Result` containing the `Viewer` if successful, or an error message as a `String`.
 pub fn get_viewer(config: &Config, token: &str) -> Result<Viewer, String> {
     let response = request::Gql::new(config, token, FETCH_IDS_DOC).run()?;
 
@@ -65,7 +87,16 @@ pub fn get_viewer(config: &Config, token: &str) -> Result<Viewer, String> {
     }
 }
 
-/// Fetch all the team names for a viewer
+/// Fetches all the team names associated with the viewer.
+///
+/// # Arguments
+///
+/// * `viewer` - A reference to the `Viewer` whose teams are to be retrieved.
+///
+/// # Returns
+///
+/// Returns a `Result` containing a vector of team names as `Vec<String>` if successful,
+/// or an error message as a `String`.
 pub fn team_names(viewer: &Viewer) -> Result<Vec<String>, String> {
     let nodes = viewer.team_memberships.nodes.clone();
     if nodes.is_empty() {
@@ -77,7 +108,16 @@ pub fn team_names(viewer: &Viewer) -> Result<Vec<String>, String> {
     Ok(names)
 }
 
-/// Fetch the project names for a team
+/// Fetches the project names for a given team.
+///
+/// # Arguments
+///
+/// * `team` - An optional reference to the `Team` whose projects are to be retrieved.
+///
+/// # Returns
+///
+/// Returns a `Result` containing a vector of project names as `Vec<String>` if successful,
+/// or an empty vector if no projects are found.
 pub fn project_names(team: &Option<Team>) -> Result<Vec<String>, String> {
     if let Some(team) = team {
         let project_names = team
@@ -95,7 +135,17 @@ pub fn project_names(team: &Option<Team>) -> Result<Vec<String>, String> {
         Ok(Vec::new())
     }
 }
-/// Fetch the team by name
+
+/// Fetches the team by its name from the viewer's list of teams.
+///
+/// # Arguments
+///
+/// * `viewer` - A reference to the `Viewer` whose teams are to be searched.
+/// * `team_name` - A string reference representing the name of the team to be fetched.
+///
+/// # Returns
+///
+/// Returns a `Result` containing the `Team` if found, or an error message as a `String`.
 pub fn team_by_name(viewer: &Viewer, team_name: &String) -> Result<Team, String> {
     let nodes = viewer.team_memberships.nodes.clone();
     if nodes.is_empty() {
@@ -117,6 +167,16 @@ pub fn team_by_name(viewer: &Viewer, team_name: &String) -> Result<Team, String>
     }
 }
 
+/// Fetches the team for the viewer based on an optional team name.
+///
+/// # Arguments
+///
+/// * `viewer` - A reference to the `Viewer` whose teams are to be searched.
+/// * `team_name` - An optional reference to a string representing the team name to search for.
+///
+/// # Returns
+///
+/// Returns a `Result` containing the selected `Team` if found, or an error message as a `String`.
 pub fn team(viewer: &Viewer, team_name: &Option<String>) -> Result<Team, String> {
     let mut team_names = team_names(viewer)?;
 
@@ -136,6 +196,16 @@ pub fn team(viewer: &Viewer, team_name: &Option<String>) -> Result<Team, String>
     }
 }
 
+/// Fetches the project by its name from a given team.
+///
+/// # Arguments
+///
+/// * `team` - An optional reference to the `Team` whose projects are to be searched.
+/// * `project_name` - A `String` representing the name of the project to be fetched.
+///
+/// # Returns
+///
+/// Returns a `Result` containing an `Option<Project>` if found, or an error message as a `String`.
 pub fn project(team: &Option<Team>, project_name: String) -> Result<Option<Project>, String> {
     if project_name.as_str() == "None" {
         return Ok(None);


### PR DESCRIPTION
Converts the CLI tool into a `lib.rs` module using a simple wrapper client around all the functions the CLI would call. This was done in a way that left the original code as intact as possible.